### PR TITLE
Feat: Implement secondary sticky-scroll and mobile navigation

### DIFF
--- a/design55/assets/js/main.js
+++ b/design55/assets/js/main.js
@@ -1,48 +1,94 @@
 jQuery(document).ready(function($) {
-  var $menu = $('.main-nav'); // Cache jQuery object
-  if ($menu.length) { // Check if the menu exists
-    var $window = $(window);
-    var menuHeight = $menu.outerHeight();
-    // Ensure origOffsetY is calculated *before* any class changes might affect its position.
-    // It's relative to the document.
-    var origOffsetY = $menu.offset().top;
+  var $window = $(window);
+  var $body = $('body');
 
-    var $spacer = $('#sticky-menu-spacer'); // Get the spacer div from footer.php
-                                          // Or create it if it doesn't exist, though it's better in PHP.
-    if (!$spacer.length) { // If spacer wasn't in footer.php, create and insert it.
-        $spacer = $('<div id="sticky-menu-spacer"></div>').css({
-            'height': menuHeight + 'px',
-            'display': 'none' // Initially hidden
-        });
-        $menu.before($spacer);
-    } else { // If it exists, ensure its height is correctly set.
-        $spacer.css({
-            'height': menuHeight + 'px',
-            'display': 'none'
-        });
-    }
+  // Secondary Sticky-Scroll Menu (Desktop)
+  var $secondaryStickyNav = $('.secondary-sticky-nav');
+  var $siteHeader = $('.site-header'); // Reference to the main header
+  var siteHeaderHeight = $siteHeader.length ? $siteHeader.outerHeight() : 0;
 
-    function onScroll() {
-      // Check current scroll position against the original offset of the menu
-      if ($window.scrollTop() >= origOffsetY) {
-        if (!$menu.hasClass('sticky-nav')) {
-          $menu.addClass('sticky-nav');
-          $spacer.show(); // Show spacer
+  if ($secondaryStickyNav.length && $siteHeader.length) {
+    function handleSecondaryNavVisibility() {
+      if ($window.width() > 600) { // Only apply for desktop
+        if ($window.scrollTop() > siteHeaderHeight) {
+          $secondaryStickyNav.addClass('secondary-sticky-nav--visible');
+        } else {
+          $secondaryStickyNav.removeClass('secondary-sticky-nav--visible');
         }
       } else {
-        if ($menu.hasClass('sticky-nav')) {
-          $menu.removeClass('sticky-nav');
-          $spacer.hide(); // Hide spacer
-        }
+        $secondaryStickyNav.removeClass('secondary-sticky-nav--visible'); // Ensure it's hidden on mobile
       }
     }
 
-    // Use a throttled scroll event for better performance if available, otherwise use regular scroll
-    // WordPress typically includes underscore.js, which has _.throttle
-    if (typeof _.throttle === 'function') {
-        $window.on('scroll', _.throttle(onScroll, 200));
-    } else {
-        $window.on('scroll', onScroll);
-    }
+    // Initial check
+    handleSecondaryNavVisibility();
+    $window.on('scroll', _.throttle(handleSecondaryNavVisibility, 150));
+    $window.on('resize', _.throttle(handleSecondaryNavVisibility, 150));
   }
+
+
+  // Mobile Menu
+  var $mobileMenuToggle = $('.mobile-menu-toggle');
+  var $mobileMenuPanel = $('.mobile-menu-panel');
+  var $mobileMenuClose = $('.mobile-menu-close');
+  var $mobileMenuOverlay = $('.mobile-menu-overlay');
+
+  if ($mobileMenuToggle.length && $mobileMenuPanel.length) {
+    function openMobileMenu() {
+      $body.addClass('mobile-menu-active');
+      $mobileMenuToggle.addClass('active').attr('aria-expanded', 'true');
+      $mobileMenuPanel.addClass('open').attr('aria-hidden', 'false');
+      $mobileMenuOverlay.addClass('active');
+    }
+
+    function closeMobileMenu() {
+      $body.removeClass('mobile-menu-active');
+      $mobileMenuToggle.removeClass('active').attr('aria-expanded', 'false');
+      $mobileMenuPanel.removeClass('open').attr('aria-hidden', 'true');
+      $mobileMenuOverlay.removeClass('active');
+    }
+
+    $mobileMenuToggle.on('click', function() {
+      if ($mobileMenuPanel.hasClass('open')) {
+        closeMobileMenu();
+      } else {
+        openMobileMenu();
+      }
+    });
+
+    $mobileMenuClose.on('click', function() {
+      closeMobileMenu();
+    });
+
+    $mobileMenuOverlay.on('click', function() {
+      closeMobileMenu();
+    });
+
+    // Close mobile menu if user clicks a link within it
+    $mobileMenuPanel.find('a').on('click', function(e) {
+        // If it's a link to a section on the same page (#hash-link), close menu
+        if (this.pathname === window.location.pathname && this.hash !== '') {
+            closeMobileMenu();
+        }
+        // For other links, the page will navigate away, so menu closure is implicit.
+        // If you want to ensure it closes even for external links before navigation,
+        // you might add closeMobileMenu(); here unconditionally, but it's usually not needed.
+    });
+
+
+    // Close on ESC key
+    $(document).on('keydown', function(e) {
+      if (e.key === "Escape" && $mobileMenuPanel.hasClass('open')) {
+        closeMobileMenu();
+      }
+    });
+  }
+
+  // Consolidate scroll and resize listeners if other functions need them
+  // For now, only the original sticky nav (if kept) and secondary nav use scroll/resize heavily.
+  // The original sticky nav logic for .main-nav is kept separate for now,
+  // as its behavior (using a spacer) is different from the secondary-sticky-nav.
+  // If .main-nav itself is NOT supposed to be sticky anymore, its related JS should be removed.
+  // Based on the new requirement, .main-nav (original one) is hidden on mobile,
+  // and secondary-sticky-nav appears on desktop scroll. So the original stickiness of .main-nav is redundant and has been removed.
 });

--- a/design55/header.php
+++ b/design55/header.php
@@ -18,6 +18,65 @@
       <span class="site-tagline"><?php bloginfo('description'); ?></span>
     </div>
     <nav class="main-nav">
-      <?php wp_nav_menu( array('theme_location' => 'main-menu') ); ?>
+      <?php wp_nav_menu( array('theme_location' => 'main-menu', 'container' => false, 'menu_class' => 'menu a-main-menu')); // Added menu_class and container=>false for better control ?>
     </nav>
+    <button class="mobile-menu-toggle" aria-label="<?php esc_attr_e('Open Mobile Menu', 'design55'); ?>" aria-expanded="false" aria-controls="mobile-menu-panel">
+        <span class="toggle-bar"></span>
+        <span class="toggle-bar"></span>
+        <span class="toggle-bar"></span>
+    </button>
   </header>
+
+<nav class="secondary-sticky-nav" aria-label="<?php esc_attr_e('Secondary Navigation', 'design55'); ?>">
+    <div class="container"> <?php // Using existing container class for alignment ?>
+        <div class="secondary-logo">
+            <?php
+            // Display a smaller version of the logo.
+            // This might involve a different custom logo size or a CSS scaled version of the main logo.
+            // For now, let's re-use the custom_logo if available, CSS will handle size.
+            if ( has_custom_logo() ) {
+                // We need a way to make it smaller.
+                // Option 1: Hope CSS handles it.
+                // Option 2: Add a filter to change logo output or use a specific smaller logo size if registered.
+                // For simplicity now, just outputting it.
+                the_custom_logo();
+            } else {
+                echo '<a href="' . esc_url(home_url('/')) . '" rel="home" class="site-name-link">' . esc_html(get_bloginfo('name')) . '</a>';
+            }
+            ?>
+        </div>
+        <?php
+            wp_nav_menu( array(
+                'theme_location' => 'main-menu',
+                'container' => false,
+                'menu_class' => 'menu a-secondary-menu', // Different class for potentially different styling
+                'depth' => 1 // Keep secondary menu simple, no dropdowns by default
+            ) );
+        ?>
+    </div>
+</nav>
+
+<div class="mobile-menu-panel" id="mobile-menu-panel" aria-hidden="true">
+    <div class="mobile-menu-header">
+        <div class="mobile-menu-logo">
+            <?php
+            if ( has_custom_logo() ) {
+                the_custom_logo(); // Again, CSS will need to control size
+            } else {
+                echo '<a href="' . esc_url(home_url('/')) . '" rel="home" class="site-name-link">' . esc_html(get_bloginfo('name')) . '</a>';
+            }
+            ?>
+        </div>
+        <button class="mobile-menu-close" aria-label="<?php esc_attr_e('Close Mobile Menu', 'design55'); ?>" aria-expanded="true">
+            &times; <?php // Simple X, can be replaced with SVG icon ?>
+        </button>
+    </div>
+    <?php
+        wp_nav_menu( array(
+            'theme_location' => 'main-menu',
+            'container' => false,
+            'menu_class' => 'menu a-mobile-menu'
+        ) );
+    ?>
+</div>
+<div class="mobile-menu-overlay"></div> <?php // For dimming content when mobile menu is open ?>

--- a/design55/style.css
+++ b/design55/style.css
@@ -279,6 +279,221 @@ ul.menu { /* WP generates this class for the <ul> */
 }
 /* End Menu item underline animation */
 
+/*--------------------------------------------------------------
+5.5 Secondary and Mobile Navigation
+--------------------------------------------------------------*/
+
+/* Secondary Sticky-Scroll Menu (Desktop) */
+.secondary-sticky-nav {
+  display: none; /* Hidden by default, shown by JS */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.95); /* Slightly opaque white */
+  backdrop-filter: blur(10px);
+  box-shadow: var(--shadow);
+  z-index: 998; /* Below main header dropdowns, above content */
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--accent-pink);
+}
+.secondary-sticky-nav .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.secondary-sticky-nav .secondary-logo img.custom-logo {
+  max-height: 40px; /* Smaller logo */
+  width: auto;
+}
+.secondary-sticky-nav .secondary-logo .site-name-link {
+    font-size: 1.5rem; /* Smaller site name if no logo */
+    color: var(--black-main);
+    font-family: var(--font-serif);
+    font-weight: 700;
+}
+
+.secondary-sticky-nav ul.a-secondary-menu {
+  display: flex;
+  gap: 1rem; /* Adjust spacing */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.secondary-sticky-nav ul.a-secondary-menu li a {
+  font-size: 0.9rem; /* Smaller font size */
+  font-family: var(--font-sans);
+  color: var(--black-secondary);
+  font-weight: 500;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-md);
+  transition: background var(--transition), color var(--transition);
+  position: relative;
+  text-decoration: none;
+  overflow: hidden;
+}
+.secondary-sticky-nav ul.a-secondary-menu li a::after {
+  content: '';
+  position: absolute;
+  bottom: -1px; /* Ensure it's below padding */
+  left: 0;
+  width: 0;
+  height: 1px; /* Thinner underline */
+  background-color: var(--accent-deep-pink);
+  transition: width 0.3s ease-in-out;
+}
+.secondary-sticky-nav ul.a-secondary-menu li a:hover,
+.secondary-sticky-nav ul.a-secondary-menu li a:focus {
+  background-color: var(--accent-pink);
+  color: var(--bg-contrast);
+}
+.secondary-sticky-nav ul.a-secondary-menu li a:hover::after,
+.secondary-sticky-nav ul.a-secondary-menu li a:focus::after,
+.secondary-sticky-nav ul.a-secondary-menu li.current-menu-item > a::after,
+.secondary-sticky-nav ul.a-secondary-menu li.current-menu-ancestor > a::after {
+  width: 100%;
+}
+
+.secondary-sticky-nav--visible {
+  display: block; /* Show the menu */
+}
+
+
+/* Mobile Menu Toggle Button (Hamburger) */
+.mobile-menu-toggle {
+  display: none; /* Hidden by default, shown on mobile */
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  margin-left: auto; /* Pushes it to the right if other items are in header flex */
+  cursor: pointer;
+  z-index: 1002; /* Above sticky nav, below mobile panel when open */
+}
+.mobile-menu-toggle .toggle-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background-color: var(--black-main);
+  margin: 4px 0;
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  border-radius: 1px;
+}
+/* Hamburger to X animation */
+.mobile-menu-toggle.active .toggle-bar:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+.mobile-menu-toggle.active .toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+.mobile-menu-toggle.active .toggle-bar:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+
+/* Mobile Menu Panel */
+.mobile-menu-panel {
+  display: block; /* Keep it in layout tree for JS */
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px; /* Adjust width as needed */
+  max-width: 80%;
+  height: 100vh;
+  background-color: var(--bg-contrast);
+  box-shadow: -5px 0 15px rgba(0,0,0,0.1);
+  z-index: 1001; /* Above content and secondary nav */
+  transform: translateX(100%); /* Initially off-screen to the right */
+  transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1); /* Smooth animation */
+  padding: 1.5rem;
+  overflow-y: auto; /* Allow scrolling if menu is long */
+}
+.mobile-menu-panel.open {
+  transform: translateX(0);
+}
+.mobile-menu-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--accent-lavender);
+}
+.mobile-menu-panel .mobile-menu-logo img.custom-logo {
+  max-height: 45px; /* Adjust as needed */
+  width: auto;
+}
+.mobile-menu-panel .mobile-menu-logo .site-name-link {
+    font-size: 1.6rem;
+    color: var(--black-main);
+    font-family: var(--font-serif);
+    font-weight: 700;
+}
+.mobile-menu-close {
+  background: none;
+  border: none;
+  font-size: 2rem; /* Make X larger */
+  color: var(--black-secondary);
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+.mobile-menu-panel ul.a-mobile-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.mobile-menu-panel ul.a-mobile-menu li {
+  margin-bottom: 0.5rem;
+}
+.mobile-menu-panel ul.a-mobile-menu li a {
+  display: block;
+  padding: 0.75rem 0.5rem;
+  font-family: var(--font-sans);
+  color: var(--black-main);
+  text-decoration: none;
+  font-size: 1.1rem;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s ease;
+}
+.mobile-menu-panel ul.a-mobile-menu li a:hover,
+.mobile-menu-panel ul.a-mobile-menu li a:focus {
+  background-color: var(--accent-pink);
+  color: #fff;
+}
+.mobile-menu-panel ul.a-mobile-menu ul.sub-menu { /* Sub-menu styling for mobile */
+    padding-left: 1rem;
+    margin-top: 0.5rem;
+    border-left: 2px solid var(--accent-lavender);
+}
+.mobile-menu-panel ul.a-mobile-menu ul.sub-menu li a {
+    font-size: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+/* Mobile Menu Overlay */
+.mobile-menu-overlay {
+  display: none; /* Hidden by default */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.5); /* Semi-transparent black */
+  z-index: 1000; /* Below mobile panel, above content */
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out;
+}
+.mobile-menu-overlay.active {
+  display: block;
+  opacity: 1;
+}
+
+/* Body class when mobile menu is open */
+body.mobile-menu-active {
+  overflow: hidden; /* Prevent scrolling of page content */
+}
+
 
 /* 5.3 Sticky Navigation */
 .main-nav.sticky-nav {
@@ -1112,6 +1327,16 @@ ul.sub-menu li a {
 @media (max-width: 600px) {
   :root {
     --container-padding: 0.8rem;
+  }
+
+  .site-header .main-nav {
+    display: none; /* Hide main navigation */
+  }
+  .site-header .mobile-menu-toggle {
+    display: block; /* Show hamburger toggle */
+  }
+  .secondary-sticky-nav {
+    display: none !important; /* Ensure secondary sticky nav is also hidden on mobile */
   }
 
   .hero-title {


### PR DESCRIPTION
- Added HTML structure to header.php for a secondary sticky-scroll navigation bar (for desktop, appears when main nav is out of view) and a mobile navigation system (hamburger toggle, slide-in panel, overlay).
- Both new menus use the 'main-menu' theme location, with the secondary menu having a depth of 1.
- Implemented CSS in style.css for:
  - Styling and initial hiding of the secondary sticky nav, and a class to show it when active.
  - Styling of the mobile menu hamburger toggle (including animation to 'X').
  - Styling of the mobile menu panel (slide-in from right animation, layout, close button).
  - Styling for the mobile menu overlay.
  - Responsive rules to hide the main navigation and secondary sticky navigation at the 600px breakpoint, showing the mobile toggle instead.
- Added JavaScript to main.js for:
  - Logic to detect scroll position and window width to show/hide the secondary sticky nav on desktop.
  - Functionality for the mobile menu: toggling panel/overlay visibility, animating the hamburger icon, preventing body scroll when the mobile menu is open, and closing the menu on link click (for hash links), close button click, overlay click, or ESC key press.
- Removed redundant JavaScript for the original main navigation's sticky behavior as it's superseded by the new navigation systems.