### PR TITLE
Refactor: Implement slide-in secondary menu and template part

### DIFF
--- a/design55/assets/js/main.js
+++ b/design55/assets/js/main.js
@@ -11,12 +11,12 @@ jQuery(document).ready(function($) {
     function handleSecondaryNavVisibility() {
       if ($window.width() > 600) { // Only apply for desktop
         if ($window.scrollTop() > siteHeaderHeight) {
-          $secondaryStickyNav.addClass('secondary-sticky-nav--visible');
+          $secondaryStickyNav.addClass('secondary-menu--active'); // Use new class for slide animation
         } else {
-          $secondaryStickyNav.removeClass('secondary-sticky-nav--visible');
+          $secondaryStickyNav.removeClass('secondary-menu--active');
         }
       } else {
-        $secondaryStickyNav.removeClass('secondary-sticky-nav--visible'); // Ensure it's hidden on mobile
+        $secondaryStickyNav.removeClass('secondary-menu--active'); // Ensure it's hidden and transform reset on mobile
       }
     }
 

--- a/design55/header.php
+++ b/design55/header.php
@@ -27,34 +27,7 @@
     </button>
   </header>
 
-<nav class="secondary-sticky-nav" aria-label="<?php esc_attr_e('Secondary Navigation', 'design55'); ?>">
-    <div class="container"> <?php // Using existing container class for alignment ?>
-        <div class="secondary-logo">
-            <?php
-            // Display a smaller version of the logo.
-            // This might involve a different custom logo size or a CSS scaled version of the main logo.
-            // For now, let's re-use the custom_logo if available, CSS will handle size.
-            if ( has_custom_logo() ) {
-                // We need a way to make it smaller.
-                // Option 1: Hope CSS handles it.
-                // Option 2: Add a filter to change logo output or use a specific smaller logo size if registered.
-                // For simplicity now, just outputting it.
-                the_custom_logo();
-            } else {
-                echo '<a href="' . esc_url(home_url('/')) . '" rel="home" class="site-name-link">' . esc_html(get_bloginfo('name')) . '</a>';
-            }
-            ?>
-        </div>
-        <?php
-            wp_nav_menu( array(
-                'theme_location' => 'main-menu',
-                'container' => false,
-                'menu_class' => 'menu a-secondary-menu', // Different class for potentially different styling
-                'depth' => 1 // Keep secondary menu simple, no dropdowns by default
-            ) );
-        ?>
-    </div>
-</nav>
+<?php get_template_part('template-parts/secondary-menu'); // Load the secondary menu template part ?>
 
 <div class="mobile-menu-panel" id="mobile-menu-panel" aria-hidden="true">
     <div class="mobile-menu-header">

--- a/design55/style.css
+++ b/design55/style.css
@@ -285,43 +285,50 @@ ul.menu { /* WP generates this class for the <ul> */
 
 /* Secondary Sticky-Scroll Menu (Desktop) */
 .secondary-sticky-nav {
-  display: none; /* Hidden by default, shown by JS */
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
-  background-color: rgba(255, 255, 255, 0.95); /* Slightly opaque white */
+  transform: translateY(-120%); /* Start off-screen; 120% to ensure it's fully hidden if it has padding/border */
+  transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+  background-color: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   box-shadow: var(--shadow);
-  z-index: 998; /* Below main header dropdowns, above content */
+  z-index: 998;
   padding: 0.5rem 0;
   border-bottom: 1px solid var(--accent-pink);
+  /* display: none; by default is not needed if transform handles initial hiding */
 }
+
+.secondary-sticky-nav.secondary-menu--active { /* Renamed class for clarity with sliding behavior */
+  transform: translateY(0); /* Slide into view */
+}
+
+/* Styles for content within .secondary-sticky-nav remain largely the same */
 .secondary-sticky-nav .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 .secondary-sticky-nav .secondary-logo img.custom-logo {
-  max-height: 40px; /* Smaller logo */
+  max-height: 40px;
   width: auto;
 }
 .secondary-sticky-nav .secondary-logo .site-name-link {
-    font-size: 1.5rem; /* Smaller site name if no logo */
+    font-size: 1.5rem;
     color: var(--black-main);
     font-family: var(--font-serif);
     font-weight: 700;
 }
-
 .secondary-sticky-nav ul.a-secondary-menu {
   display: flex;
-  gap: 1rem; /* Adjust spacing */
+  gap: 1rem;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 .secondary-sticky-nav ul.a-secondary-menu li a {
-  font-size: 0.9rem; /* Smaller font size */
+  font-size: 0.9rem;
   font-family: var(--font-sans);
   color: var(--black-secondary);
   font-weight: 500;
@@ -335,10 +342,10 @@ ul.menu { /* WP generates this class for the <ul> */
 .secondary-sticky-nav ul.a-secondary-menu li a::after {
   content: '';
   position: absolute;
-  bottom: -1px; /* Ensure it's below padding */
+  bottom: -1px;
   left: 0;
   width: 0;
-  height: 1px; /* Thinner underline */
+  height: 1px;
   background-color: var(--accent-deep-pink);
   transition: width 0.3s ease-in-out;
 }
@@ -353,10 +360,7 @@ ul.menu { /* WP generates this class for the <ul> */
 .secondary-sticky-nav ul.a-secondary-menu li.current-menu-ancestor > a::after {
   width: 100%;
 }
-
-.secondary-sticky-nav--visible {
-  display: block; /* Show the menu */
-}
+/* .secondary-sticky-nav--visible class is now replaced by .secondary-menu--active */
 
 
 /* Mobile Menu Toggle Button (Hamburger) */

--- a/design55/template-parts/secondary-menu.php
+++ b/design55/template-parts/secondary-menu.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Template Part for the Secondary Sticky-Scroll Navigation menu.
+ *
+ * @package Design55
+ */
+?>
+<nav class="secondary-sticky-nav" aria-label="<?php esc_attr_e('Secondary Navigation', 'design55'); ?>">
+    <div class="container"> <?php // Using existing container class for alignment ?>
+        <div class="secondary-logo">
+            <?php
+            // Display a smaller version of the logo.
+            // CSS will primarily handle the sizing.
+            if ( has_custom_logo() ) {
+                the_custom_logo();
+            } else {
+                // Fallback to site name if no custom logo.
+                echo '<a href="' . esc_url(home_url('/')) . '" rel="home" class="site-name-link">' . esc_html(get_bloginfo('name')) . '</a>';
+            }
+            ?>
+        </div>
+        <?php
+            wp_nav_menu( array(
+                'theme_location' => 'main-menu',
+                'container'      => false,
+                'menu_class'     => 'menu a-secondary-menu', // Class for styling this specific menu instance
+                'depth'          => 1 // Keep secondary menu simple, no dropdowns by default
+            ) );
+        ?>
+    </div>
+</nav>


### PR DESCRIPTION
- Moved the secondary sticky navigation HTML into its own template part: `template-parts/secondary-menu.php`.
- Updated `header.php` to load the secondary menu via `get_template_part()`.
- Modified CSS for `.secondary-sticky-nav`:
  - It now slides down from the top (using `transform: translateY()`) when activated, instead of just changing display property.
  - Uses class `.secondary-menu--active` to trigger the slide-in animation.
  - Initial state is off-screen above the viewport.
- Updated JavaScript in `main.js`:
  - The `handleSecondaryNavVisibility` function now toggles the `.secondary-menu--active` class to control the slide animation.
- Ensured that the main navigation in the site header scrolls normally without any sticky behavior.
- Mobile menu functionality and visibility rules remain as previously implemented.